### PR TITLE
Admin: Status Edit form fixed and reimplemented, duplicate list entry bug fixed

### DIFF
--- a/src/AdminBundle/Resources/views/Status/edit.html.twig
+++ b/src/AdminBundle/Resources/views/Status/edit.html.twig
@@ -11,19 +11,7 @@
     </tr>
     <tr>
         <td>Index Placement</td>
-        <td>
-            <select id="form_pindex" name="form[pindex]">
-            {% for key in statusall %}
-                <option value="{{ key.pindex }}">
-                    {{ key.name|trans }}
-                </option>
-            {% endfor %}
-            </select>
-        </td>
-        <td>
-            {{ form_widget(form.placement) }}
-        </td>
-    </tr>
+        <td>{{ form_widget(form.pindex) }}</td>
     <tr>
         <td>&nbsp;</td>     
         <td>{{ form_widget(form.save) }}</td>

--- a/src/AdminBundle/Resources/views/Status/index.html.twig
+++ b/src/AdminBundle/Resources/views/Status/index.html.twig
@@ -14,13 +14,12 @@
             <td>{{ a.pindex }}</td>
             <td>{{ a.name }}</td>
             <td>
-                {#
                 <a href="{{ path("status_edit", {id: a.id}) }}">
                     <button type="button" class="btn btn-default">
                         {% trans %}Edit{% endtrans %}
-                    </button></a>
-                #}
-                {% if a.exist is null %}
+                    </button>
+                </a>
+                {% if a.product_count == 0 %}
                 <a href="{{ path("status_delete", {id: a.id, pindex: a.pindex}) }}">
                     <button type="button" class="btn btn-danger" href="#">
                         {% trans %}Delete{% endtrans %}


### PR DESCRIPTION
- De status module van het adminpaneel werkt weer, je kan statuses wijzigen en verwijderen.
- Bug die kloon kopieën van dezelfde status weergeeft opgelost, dit was een SQL join fout