### PR TITLE
Auto-select search query in product list if search query looks like an SKU

### DIFF
--- a/web/js/scripts.js
+++ b/web/js/scripts.js
@@ -1,6 +1,7 @@
 ﻿
 
 $(document).ready(function () {
+    enableAutoSelect();
 
     $('[data-toggle="tooltip"]').tooltip({
         placement: 'auto right',
@@ -57,4 +58,21 @@ function focusBarcodeInput() {
         $('input.focus:first').select();
         $('input.focus:first').focus();
     //}
+}
+
+function enableAutoSelect() {
+  pathname = window.location.pathname
+  // only apply this functionality in the product list
+  if(pathname.indexOf('/product/') === pathname.length-9) {
+    $("#index_search_form_query").bind("focus", function(event) {
+      // only select the value if input value looks like a SKU
+      if(looksLikeSKU(event.currentTarget.value)) {
+        event.currentTarget.select()
+      }
+    })
+  }
+}
+
+function looksLikeSKU(string) {
+  return string.length == 10 && parseInt(string).toString() == string
 }

--- a/web/js/scripts.js
+++ b/web/js/scripts.js
@@ -74,5 +74,5 @@ function enableAutoSelect() {
 }
 
 function looksLikeSKU(string) {
-  return string.length == 10 && parseInt(string).toString() == string
+  return /^\d{10}$/.test(string)
 }


### PR DESCRIPTION
After doing a search, the query field already gets focus automatically. So with this change, after having searched for one product with the barcode scanner, it should be possible to instantly search for a new product by simply using the scanner. This takes away a few clicks when handling a batch of products.